### PR TITLE
feat : build heap 메모리 용량 8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx4g
+gradle.startParam.maxHeapSize = "4g"


### PR DESCRIPTION
- CI 빌드시 리액트 빌드 실패 원인
- build.gradle 힙 메모리 용량 설정